### PR TITLE
Update dependecies and support swoole 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,16 @@
     "type": "library",
     "require": {
         "php": "^8.0",
-        "ext-swoole": "^4.8",
         "slim/slim": "^4.9",
-        "leocavalcante/request-callback": "^0.1.1"
+        "leocavalcante/request-callback": "dev-main"
     },
     "require-dev": {
         "swoole/ide-helper": "^4.8"
     },
     "suggest": {
-        "ext-inotify": "Needed to enable hot code reloading"
+        "ext-inotify": "Needed to enable hot code reloading",
+        "ext-swoole": "You need either ext-swoole or ext-openswoole",
+        "ext-openswoole": "You need either ext-swoole or ext-openswoole"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "leocavalcante/request-callback": "dev-main"
     },
     "require-dev": {
-        "swoole/ide-helper": "^4.8"
+        "swoole/ide-helper": "^5.0",
+        "phpstan/phpstan": "^1.9"
     },
     "suggest": {
         "ext-inotify": "Needed to enable hot code reloading",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ce156cd48902eeb3015762bb4c90048",
+    "content-hash": "15223e369099fdaaf772179a32d72324",
     "packages": [
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.20.0",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "10696c809866bebd9d71dca14de6c0d6c1cac2f8"
+                "reference": "6028af6c3b5ced4d063a680d2483cce67578b902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/10696c809866bebd9d71dca14de6c0d6c1cac2f8",
-                "reference": "10696c809866bebd9d71dca14de6c0d6c1cac2f8",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/6028af6c3b5ced4d063a680d2483cce67578b902",
+                "reference": "6028af6c3b5ced4d063a680d2483cce67578b902",
                 "shasum": ""
             },
             "require": {
@@ -39,10 +39,10 @@
                 "ext-libxml": "*",
                 "http-interop/http-factory-tests": "^0.9.0",
                 "laminas/laminas-coding-standard": "^2.4.0",
-                "php-http/psr7-integration-tests": "^1.1.1",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.28"
+                "php-http/psr7-integration-tests": "^1.2",
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "extra": {
@@ -101,36 +101,40 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-25T13:35:54+00:00"
+            "time": "2022-12-20T12:22:40+00:00"
         },
         {
             "name": "leocavalcante/request-callback",
-            "version": "v0.1.1",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/leocavalcante/request-callback.git",
-                "reference": "3309ad25a86ac9262b81ea3d327a491850f20509"
+                "reference": "7302002c18e303762d4fb75f42a06b545143f48c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/leocavalcante/request-callback/zipball/3309ad25a86ac9262b81ea3d327a491850f20509",
-                "reference": "3309ad25a86ac9262b81ea3d327a491850f20509",
+                "url": "https://api.github.com/repos/leocavalcante/request-callback/zipball/7302002c18e303762d4fb75f42a06b545143f48c",
+                "reference": "7302002c18e303762d4fb75f42a06b545143f48c",
                 "shasum": ""
             },
             "require": {
-                "ext-swoole": "^4.5",
-                "laminas/laminas-diactoros": "^2.5",
+                "laminas/laminas-diactoros": "^2.8",
                 "php": ">=7.4",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
                 "psr/http-server-handler": "^1.0"
             },
             "require-dev": {
-                "laminas/laminas-stratigility": "^3.3",
-                "pestphp/pest": "^0.3.19 || ^1.0.0",
-                "swoole/ide-helper": "^4.5",
-                "vimeo/psalm": "^4.3"
+                "laminas/laminas-stratigility": "^3.5",
+                "pestphp/pest": "^1.20.0",
+                "swoole/ide-helper": "^4.7",
+                "vimeo/psalm": "^4.12"
             },
+            "suggest": {
+                "ext-openswoole": "You need either ext-swoole or ext-openswoole",
+                "ext-swoole": "You need either ext-swoole or ext-openswoole"
+            },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -162,9 +166,9 @@
             ],
             "support": {
                 "issues": "https://github.com/leocavalcante/request-callback/issues",
-                "source": "https://github.com/leocavalcante/request-callback/tree/v0.1.1"
+                "source": "https://github.com/leocavalcante/request-callback/tree/main"
             },
-            "time": "2021-01-21T20:46:08+00:00"
+            "time": "2022-11-08T11:21:09+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -543,16 +547,16 @@
         },
         {
             "name": "slim/slim",
-            "version": "4.10.0",
+            "version": "4.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slimphp/Slim.git",
-                "reference": "0dfc7d2fdf2553b361d864d51af3fe8a6ad168b0"
+                "reference": "b0f4ca393ea037be9ac7292ba7d0a34d18bac0c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slimphp/Slim/zipball/0dfc7d2fdf2553b361d864d51af3fe8a6ad168b0",
-                "reference": "0dfc7d2fdf2553b361d864d51af3fe8a6ad168b0",
+                "url": "https://api.github.com/repos/slimphp/Slim/zipball/b0f4ca393ea037be9ac7292ba7d0a34d18bac0c7",
+                "reference": "b0f4ca393ea037be9ac7292ba7d0a34d18bac0c7",
                 "shasum": ""
             },
             "require": {
@@ -567,21 +571,21 @@
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "adriansuter/php-autoload-override": "^1.2",
+                "adriansuter/php-autoload-override": "^1.3",
                 "ext-simplexml": "*",
-                "guzzlehttp/psr7": "^2.1",
+                "guzzlehttp/psr7": "^2.4",
                 "httpsoft/http-message": "^1.0",
                 "httpsoft/http-server-request": "^1.0",
-                "laminas/laminas-diactoros": "^2.8",
+                "laminas/laminas-diactoros": "^2.17",
                 "nyholm/psr7": "^1.5",
                 "nyholm/psr7-server": "^1.0",
                 "phpspec/prophecy": "^1.15",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan": "^1.8",
                 "phpunit/phpunit": "^9.5",
                 "slim/http": "^1.2",
                 "slim/psr7": "^1.5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "suggest": {
                 "ext-simplexml": "Needed to support XML format in BodyParsingMiddleware",
@@ -654,7 +658,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-14T14:18:23+00:00"
+            "time": "2022-11-06T16:33:39+00:00"
         }
     ],
     "packages-dev": [
@@ -703,12 +707,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "leocavalcante/request-callback": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0",
-        "ext-swoole": "^4.8"
+        "php": "^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15223e369099fdaaf772179a32d72324",
+    "content-hash": "31e2e26af3a4e33d275e119bae6c953c",
     "packages": [
         {
             "name": "laminas/laminas-diactoros",
@@ -663,17 +663,76 @@
     ],
     "packages-dev": [
         {
-            "name": "swoole/ide-helper",
-            "version": "4.8.12",
+            "name": "phpstan/phpstan",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/swoole/ide-helper.git",
-                "reference": "afe3a09f8c49a6011e2206a03e55e391d97d81b0"
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "d03bccee595e2146b7c9d174486b84f4dc61b0f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/afe3a09f8c49a6011e2206a03e55e391d97d81b0",
-                "reference": "afe3a09f8c49a6011e2206a03e55e391d97d81b0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d03bccee595e2146b7c9d174486b84f4dc61b0f2",
+                "reference": "d03bccee595e2146b7c9d174486b84f4dc61b0f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-17T13:33:52+00:00"
+        },
+        {
+            "name": "swoole/ide-helper",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swoole/ide-helper.git",
+                "reference": "f9cdf7bfb70ef3a8a2b8e9eb14ce3d09c02524fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/f9cdf7bfb70ef3a8a2b8e9eb14ce3d09c02524fa",
+                "reference": "f9cdf7bfb70ef3a8a2b8e9eb14ce3d09c02524fa",
                 "shasum": ""
             },
             "type": "library",
@@ -690,7 +749,7 @@
             "description": "IDE help files for Swoole.",
             "support": {
                 "issues": "https://github.com/swoole/ide-helper/issues",
-                "source": "https://github.com/swoole/ide-helper/tree/4.8.12"
+                "source": "https://github.com/swoole/ide-helper/tree/5.0.1"
             },
             "funding": [
                 {
@@ -702,7 +761,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-22T16:31:12+00:00"
+            "time": "2022-11-08T07:13:40+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Provides support of swoole 5 and openswoole extensions but switches to depend of `dev` version of `leocavalcante/request-callback` because the latest version is not support latest versions of swooles.
